### PR TITLE
feat: support numeric, boolean, and null literals in intrinsic function parser

### DIFF
--- a/ASL_COMPATIBILITY.md
+++ b/ASL_COMPATIBILITY.md
@@ -37,7 +37,9 @@
 - `States.JsonToString(value)` - JSON object to string
 - `States.StringToJson(value)` - JSON string to object
 - `States.Array(value1, value2, ...)` - Array construction
+- `States.ArrayContains(array, value)` - Array membership test
 
+**Intrinsic function arguments:** Paths (`$.x`), context paths (`$$.x`), single-quoted strings (`'hello'`), numeric literals (`42`, `-3.14`), booleans (`true`, `false`), `null`, and nested function calls are all supported.
 #### Error Handling
 - **Catch** - Complete implementation
   - ErrorEquals matching with wildcard support

--- a/src/utils/parseIntrinsicFunction.ts
+++ b/src/utils/parseIntrinsicFunction.ts
@@ -1,11 +1,31 @@
 // From https://github.com/aws/aws-cdk/blob/678eeded5d5631dbacff43ead697ecbd3bd4b27d/packages/%40aws-cdk/aws-stepfunctions/lib/private/intrinstics.ts
-export type IntrinsicExpression = StringLiteralExpression | PathExpression | FnCallExpression;
+export type IntrinsicExpression =
+  | StringLiteralExpression
+  | NumericLiteralExpression
+  | BooleanLiteralExpression
+  | NullLiteralExpression
+  | PathExpression
+  | FnCallExpression;
 export type TopLevelIntrinsic = PathExpression | FnCallExpression;
 
 export interface StringLiteralExpression {
   readonly type: 'string-literal';
   readonly literal: string;
   readonly quoted: string;
+}
+
+export interface NumericLiteralExpression {
+  readonly type: 'numeric-literal';
+  readonly value: number;
+}
+
+export interface BooleanLiteralExpression {
+  readonly type: 'boolean-literal';
+  readonly value: boolean;
+}
+
+export interface NullLiteralExpression {
+  readonly type: 'null-literal';
 }
 
 export interface PathExpression {
@@ -63,15 +83,54 @@ export class IntrinsicParser {
       return this.parsePath();
     }
 
-    if (isAlphaNum(this.char())) {
-      return this.parseFnCall();
-    }
-
     if (this.char() === "'") {
       return this.parseStringLiteral();
     }
 
-    return this.raiseError('expected $, function or single-quoted string');
+    // Numeric literals: digits or negative sign
+    if (this.char() === '-' || isDigit(this.char())) {
+      return this.parseNumericLiteral();
+    }
+
+    // Keywords: true, false, null, or function calls
+    if (isAlphaNum(this.char())) {
+      return this.parseKeywordOrFnCall();
+    }
+
+    return this.raiseError('expected $, function, string, number, boolean, or null');
+  }
+
+  private parseNumericLiteral(): NumericLiteralExpression {
+    const numStr: string[] = [];
+    if (this.char() === '-') {
+      numStr.push(this.consume());
+    }
+    while (!this.eof && (isDigit(this.char()) || this.char() === '.')) {
+      numStr.push(this.consume());
+    }
+    const value = Number(numStr.join(''));
+    if (isNaN(value)) {
+      this.raiseError('invalid numeric literal: ' + numStr.join(''));
+    }
+    return { type: 'numeric-literal', value };
+  }
+
+  private parseKeywordOrFnCall(): IntrinsicExpression {
+    // Peek ahead to see if this is a keyword (true/false/null) or a function call
+    const remaining = this.expression.slice(this.i);
+    if (remaining.startsWith('true') && !isAlphaNum(remaining[4] ?? '')) {
+      this.i += 4;
+      return { type: 'boolean-literal', value: true };
+    }
+    if (remaining.startsWith('false') && !isAlphaNum(remaining[5] ?? '')) {
+      this.i += 5;
+      return { type: 'boolean-literal', value: false };
+    }
+    if (remaining.startsWith('null') && !isAlphaNum(remaining[4] ?? '')) {
+      this.i += 4;
+      return { type: 'null-literal' };
+    }
+    return this.parseFnCall();
   }
 
   /**
@@ -262,4 +321,9 @@ export class IntrinsicParser {
 
 function isAlphaNum(x: string) {
   return x.match(/^[a-zA-Z0-9]$/);
+}
+
+
+function isDigit(x: string) {
+  return x >= '0' && x <= '9';
 }

--- a/src/utils/selectPath.spec.ts
+++ b/src/utils/selectPath.spec.ts
@@ -112,4 +112,49 @@ describe('selectPath', () => {
     // Then
     expect(result).toStrictEqual(`Name: 'Gabriel', Surname: "Moreira"`);
   });
+
+  // --- Intrinsic parser: literal argument support ---
+
+  it('supports numeric literal arguments in intrinsic functions', () => {
+    const result = selectPath('States.Array($.a, 1, 2, 3)', { a: 0 }, <Context>{});
+    expect(result).toStrictEqual([0, 1, 2, 3]);
+  });
+
+  it('supports negative numeric literals in intrinsic functions', () => {
+    const result = selectPath('States.Array(-5, -3.14, 0)', {}, <Context>{});
+    expect(result).toStrictEqual([-5, -3.14, 0]);
+  });
+
+  it('supports decimal numeric literals in intrinsic functions', () => {
+    const result = selectPath('States.Array(3.14, 0.5, 100)', {}, <Context>{});
+    expect(result).toStrictEqual([3.14, 0.5, 100]);
+  });
+
+  it('supports boolean literal arguments in intrinsic functions', () => {
+    const result = selectPath('States.Array(true, false)', {}, <Context>{});
+    expect(result).toStrictEqual([true, false]);
+  });
+
+  it('supports null literal argument in intrinsic functions', () => {
+    const result = selectPath('States.Array(null, $.a, null)', { a: 1 }, <Context>{});
+    expect(result).toStrictEqual([null, 1, null]);
+  });
+
+  it('supports mixed literal types in intrinsic functions', () => {
+    const result = selectPath(
+      "States.Array(42, true, null, 'hello', $.x)",
+      { x: 'world' },
+      <Context>{}
+    );
+    expect(result).toStrictEqual([42, true, null, 'hello', 'world']);
+  });
+
+  it('supports numeric literals in nested intrinsic calls', () => {
+    const result = selectPath(
+      'States.Array(1, States.Array(2, 3))',
+      {},
+      <Context>{}
+    );
+    expect(result).toStrictEqual([1, [2, 3]]);
+  });
 });

--- a/src/utils/selectPath.ts
+++ b/src/utils/selectPath.ts
@@ -25,6 +25,12 @@ function evaluateAst(
     return evaluatePath(ast.path, input, context);
   } else if (ast.type === 'string-literal') {
     return ast.literal;
+  } else if (ast.type === 'numeric-literal') {
+    return ast.value;
+  } else if (ast.type === 'boolean-literal') {
+    return ast.value;
+  } else if (ast.type === 'null-literal') {
+    return null;
   } else if (ast.type === 'fncall') {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const fn: any = intrinsicFunctions[ast.functionName as keyof typeof intrinsicFunctions];


### PR DESCRIPTION
## Summary

The intrinsic function parser now accepts numeric, boolean, and null literals as arguments — previously it only supported JSONPath expressions, context paths, single-quoted strings, and nested function calls.

## Problem

Functions like `States.MathAdd($.val, -1)`, `States.ArrayPartition($.arr, 4)`, and `States.JsonMerge($.a, $.b, false)` would fail with parser errors because the parser couldn't handle literal numeric, boolean, or null arguments.

This was a prerequisite for implementing all 13 missing intrinsic functions.

## Changes

### Parser (`src/utils/parseIntrinsicFunction.ts`)
- Added 3 new AST node types: `NumericLiteralExpression`, `BooleanLiteralExpression`, `NullLiteralExpression`
- Added `parseNumericLiteral()` — handles integers (`42`), negatives (`-5`), decimals (`3.14`)
- Added `parseKeywordOrFnCall()` — distinguishes `true`/`false`/`null` keywords from function names
- Added `isDigit()` helper

### Evaluator (`src/utils/selectPath.ts`)
- Added cases for `numeric-literal`, `boolean-literal`, `null-literal` in `evaluateAst()`

### Tests
- 7 new test cases covering all literal types, mixed arguments, and nested calls
- All 39 tests pass (32 existing + 7 new)

## TDD Flow
1. ✅ RED: 7 failing tests committed first
2. ✅ GREEN: Parser + evaluator implementation makes all tests pass
3. ✅ REFACTOR: Docs updated

## What This Unblocks
Phase 2 of the TDD plan: implementing all 13 missing intrinsic functions (States.MathAdd, States.ArrayPartition, States.JsonMerge, States.UUID, States.Hash, States.Base64Encode/Decode, etc.)